### PR TITLE
Added authorization header to GET and POST user requests

### DIFF
--- a/frontend/app/models/user-store/user-store.ts
+++ b/frontend/app/models/user-store/user-store.ts
@@ -43,8 +43,8 @@ export const UserStoreModel = types
       })
     },
 
-    getUser: (token: string, id: string) => {
-     return self.environment.api.getUser(token, id).then(res => {
+    getUser: (id: string) => {
+     return self.environment.api.getUser(id).then(res => {
       if (res.kind == "ok") {
         self.setUser(res.user);
         __DEV__ && console.log("got response")

--- a/frontend/app/navigation/root-navigator.tsx
+++ b/frontend/app/navigation/root-navigator.tsx
@@ -42,10 +42,8 @@ const RootStack = observer(() => {
   // Handle user state changes
   function onAuthStateChanged(res) {
     if (res)
-      res.getIdToken().then((token) => {
-        userStore.getUser(token, res._user.uid).then((_) => {
-          if (initializing) setInitializing(false)
-        })
+      userStore.getUser(res._user.uid).then((_) => {
+        if (initializing) setInitializing(false)
       })
     else {
       if (initializing) setInitializing(false)

--- a/frontend/app/services/api/api.ts
+++ b/frontend/app/services/api/api.ts
@@ -2,6 +2,7 @@ import { ApisauceInstance, create, ApiResponse } from "apisauce"
 import { getGeneralApiProblem } from "./api-problem"
 import { ApiConfig, DEFAULT_API_CONFIG } from "./api-config"
 import * as Types from "./api.types"
+import auth from "@react-native-firebase/auth"
 
 /**
  * Manages all requests to the API.
@@ -50,6 +51,9 @@ export class Api {
    */
   async postUserSignIn(id: string, name: string, email: string): Promise<Types.PostUserSignInResult> {
 
+    const idToken = await auth().currentUser.getIdToken();
+    this.apisauce.setHeader("Authorization", idToken);
+
     const postUsr: Types.PostUser = {email: email, username: name, id: id}
 
     const response: ApiResponse<any> = await this.apisauce.post("/users", postUsr)
@@ -81,8 +85,10 @@ export class Api {
    * Gets a single user by ID
    */
 
-  async getUser(token: string, id: string): Promise<Types.GetUserResult> {
+  async getUser(id: string): Promise<Types.GetUserResult> {
     // make the api call
+    const idToken = await auth().currentUser.getIdToken();
+    this.apisauce.setHeader("Authorization", idToken);
     const response: ApiResponse<any> = await this.apisauce.get(`/users/${id}`)
 
     // the typical ways to die when calling an api


### PR DESCRIPTION
Simple change, I believe updated the request headers should only be necessary during GET and POST user requests. 

All other requests will have this header by default but should not need to update it. (GET and POST user will be called whenever someone signs out)