### PR TITLE
Simple fix to add bearer to front of auth token

### DIFF
--- a/frontend/app/services/api/api.ts
+++ b/frontend/app/services/api/api.ts
@@ -112,7 +112,7 @@ export class Api {
     const postUsr: Types.PostUser = { email: email, username: name, id: id, notificationId: notId }
 
     const idToken = await auth().currentUser.getIdToken();
-    this.apisauce.setHeader("Authorization", idToken);
+    this.apisauce.setHeader("Authorization", "Bearer " + idToken);
 
     const response: ApiResponse<any> = await this.apisauce.post("/users", postUsr)
 
@@ -146,7 +146,7 @@ export class Api {
   async getUser(id: string): Promise<Types.GetUserResult> {
     // make the api call
     const idToken = await auth().currentUser.getIdToken();
-    this.apisauce.setHeader("Authorization", idToken);
+    this.apisauce.setHeader("Authorization", "Bearer " + idToken);
     const response: ApiResponse<any> = await this.apisauce.get(`/users/${id}`)
 
     // the typical ways to die when calling an api


### PR DESCRIPTION
This aligns with the backend so that the auth token can be read by taking the auth token after the `Bearer` string.